### PR TITLE
Update README with missing UpdateRemotePlugins step

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ manager.
 Vundle:
 `Plugin 'TheZoq2/neovim-auto-autoread'`
 
+Once installed, run the following command to update the remote plugin manifest:
+
+`:UpdateRemotePlugins`
+
 Add the following to your .vimrc 
 ```
     "Autoreload files when changed externally


### PR DESCRIPTION
Hi Frans,

Many thanks for the useful plugin - I noticed that one has to run `:UpdateRemotePlugins` for the pluging to load (when using a plugin manager or manually installing) so have added this step to the readme.

Cheers,

Andrew